### PR TITLE
Create generic `ObjectPool<T>` class

### DIFF
--- a/Assets/Scripts/Tickle/Utils.meta
+++ b/Assets/Scripts/Tickle/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f68350485bb096544b6ced748326d9e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tickle/Utils/ObjectPool.cs
+++ b/Assets/Scripts/Tickle/Utils/ObjectPool.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tickle.Utils
+{
+    public class ObjectPool<T> where T : class
+    {
+        /// <summary>
+        /// NOTE: Uninit by default 
+        /// </summary>
+        public static ObjectPool<T> Shared;
+
+        private readonly Stack<T> _pooled;
+        private readonly Func<T> _generator;
+
+        public ObjectPool(Func<T> objectGenerator, bool thisAsShared = false)
+        {
+            _generator = objectGenerator ??
+                throw new ArgumentNullException(nameof(objectGenerator));
+            _pooled = new Stack<T>();
+            Shared = thisAsShared ? this : null;
+        }
+
+        public T Rent() => _pooled.Count > 0 ? _pooled.Pop() : _generator();
+
+        public void Return(T item) => _pooled.Push(item);
+    }
+}

--- a/Assets/Scripts/Tickle/Utils/ObjectPool.cs.meta
+++ b/Assets/Scripts/Tickle/Utils/ObjectPool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83cdcf55ba3108f4c9136a9c5b0fa854


### PR DESCRIPTION
Addresses #7 

Just adding a generic object pool class that can store a global instance of itself. It utilizes .NET's base collection primitives from `System.Collection.Generic`.