### PR TITLE
Add VSCode directory in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
Currently, there is no use case for a `.vscode` directory. VSCode is also a popular code editor which will create a `.vscode` directory on load of the project. Hence, adding this in the `.gitignore` will prevent these added files from being detected as new changes.